### PR TITLE
Payment detail modal

### DIFF
--- a/src/app/features/payment-requests/components/payment-detail-modal/payment-detail-modal.component.html
+++ b/src/app/features/payment-requests/components/payment-detail-modal/payment-detail-modal.component.html
@@ -1,0 +1,76 @@
+<!-- Fondo con blur -->
+<div class="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50">
+  <!-- Caja del modal -->
+  <section
+    class="bg-white rounded-xl shadow-lg w-full max-w-md p-6 relative"
+    role="dialog" 
+    aria-modal="true" 
+    aria-labelledby="modal-title">
+  
+    <!-- Botón cerrar -->
+    <button 
+      (click)="close()"
+      class="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors"
+      aria-label="Cerrar modal">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+           stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+      </svg>
+    </button>
+
+    <header>
+      <h3 class="text-lg font-bold text-gray-800 pb-2">
+        Detalle de Solicitud
+      </h3>
+    </header>
+
+    <!-- Contenido -->
+    <div *ngIf="payment as payment; else noData">
+      <dl class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <!-- ID -->
+        <div>
+          <dt class="text-sm text-gray-500">ID</dt>
+          <dd class="font-semibold text-gray-800">{{ payment.id_sp }}</dd>
+        </div>
+        <!-- Descripción ocupa toda la fila -->
+        <div class="md:col-span-2">
+          <dt class="text-sm text-gray-500">Descripción</dt>
+          <dd class="font-semibold text-gray-800 break-words">{{ payment.descripcion }}</dd>
+        </div>
+        <!-- Importes -->
+        <div>
+          <dt class="text-sm text-gray-500">Importe Pagado</dt>
+          <dd class="font-semibold text-gray-800">{{ payment.importe_pagado | currency:'USD' }}</dd>
+        </div>
+        <div *ngIf="payment.importe" class="md:col-span-2">
+          <dt class="text-sm text-gray-500">Importe Original</dt>
+          <dd class="font-semibold text-gray-800">{{ payment.importe | currency:'USD' }}</dd>
+        </div>
+        <div *ngIf="payment.importe_vencido" class="col-span-2">
+          <dt class="text-sm text-gray-500">Importe Vencido</dt>
+          <dd class="font-semibold text-red-600">{{ payment.importe_vencido | currency:'USD' }}</dd>
+        </div>
+        <!-- Estado y medio de pago -->
+        <div>
+          <dt class="text-sm text-gray-500">Estado</dt>
+          <dd>
+            <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full"
+                  [class]="payment.estado_pago | paymentStatus:'class'">
+              {{ payment.estado_pago | paymentStatus:'text' }}
+            </span>
+          </dd>
+        </div>
+        
+        <div>
+          <dt class="text-sm text-gray-500">Medio de Pago</dt>
+          <dd class="font-semibold">{{ payment.medio_pago }}</dd>
+        </div>
+      </dl>
+    </div>
+
+    <ng-template #noData>
+      <p class="text-gray-500">No hay información disponible.</p>
+    </ng-template>
+  </section>
+</div>
+

--- a/src/app/features/payment-requests/components/payment-detail-modal/payment-detail-modal.component.ts
+++ b/src/app/features/payment-requests/components/payment-detail-modal/payment-detail-modal.component.ts
@@ -1,0 +1,22 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PaymentRequest } from '../../models/payment-request.model';
+import { PaymentStatusPipe } from '../../pipes/payment-status.pipe';
+
+@Component({
+  selector: 'app-payment-detail-modal',
+  standalone: true,
+  imports: [CommonModule, PaymentStatusPipe],
+  templateUrl: './payment-detail-modal.component.html',
+})
+export class PaymentDetailModalComponent {
+  /** Pago seleccionado a mostrar */
+  @Input() payment: PaymentRequest | null = null;
+
+  /** Evento para cerrar el modal */
+  @Output() closed = new EventEmitter<void>();
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/src/app/features/payment-requests/components/payment-list/payment-list.component.ts
+++ b/src/app/features/payment-requests/components/payment-list/payment-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy} from '@angular/core';
 import { PaymentRequest } from '../../models/payment-request.model';
 import { CommonModule } from '@angular/common';
 import { PaymentStatusPipe } from '../../pipes/payment-status.pipe';
@@ -18,8 +18,9 @@ export class PaymentListComponent {
    onPaymentSelect(payment: PaymentRequest): void {
     this.paymentSelect.emit(payment);
   }
+
   onPaymentDetail(payment: PaymentRequest, event: Event): void {
-    // no se dispare también el evento de selección de toda la fila.
+    // Evita que se dispare el evento de selección de fila
     event.stopPropagation(); 
     this.paymentDetail.emit(payment);
   }

--- a/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.html
+++ b/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.html
@@ -31,8 +31,15 @@
       <!-- Lista de pagos -->
     <app-payment-list
       *ngIf="!isLoading() && !error()"
-      [payments]="pagos()"> 
+      [payments]="pagos()"
+      (paymentDetail)="onPaymentDetail($event)">
     </app-payment-list>
+
+    <app-payment-detail-modal
+      *ngIf="selectedPayment()"
+      [payment]="selectedPayment()"
+      (closed)="onCloseDetail()">
+    </app-payment-detail-modal>
 
    <!-- Mensaje cuando no hay pagos  -->
     <div *ngIf="!isLoading() && !error() && pagos().length === 0"  

--- a/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.ts
+++ b/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.ts
@@ -13,6 +13,7 @@ import { PaymentRequest } from '../../models/payment-request.model';
 import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
 import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import { SearchBoxComponent } from '../../../../shared/components/search-box.component';
+import { PaymentDetailModalComponent } from '../../components/payment-detail-modal/payment-detail-modal.component';
 
 
 @Component({
@@ -24,7 +25,8 @@ import { SearchBoxComponent } from '../../../../shared/components/search-box.com
     PaymentLoaderComponent,
     PaginationComponent,
     ReactiveFormsModule,
-    SearchBoxComponent
+    SearchBoxComponent,
+    PaymentDetailModalComponent
   ],
   templateUrl: './payment-list-page.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -50,7 +52,7 @@ export class PaymentListPageComponent {
     this.loadPayments();
   }
 
-  /** 🔎 Búsqueda por ID */
+  /** Búsqueda por ID */
   onSearchById(id: string): void {
     if (!id) {
       this.onRefresh();
@@ -83,7 +85,7 @@ export class PaymentListPageComponent {
       });
   }
 
-  /** 📄 Cargar lista paginada */
+  /** Cargar lista paginada */
   loadPayments(): void {
     this.isLoading.set(true);
     this.error.set(null);
@@ -118,15 +120,25 @@ export class PaymentListPageComponent {
       });
   }
 
-  /** 🔄 Refrescar lista */
+  /**Refrescar lista */
   onRefresh(): void {
     this._currentPage.set(1);
     this.loadPayments();
   }
 
-  /** 📑 Cambiar página */
+  /** Cambiar página */
   onPageChange(page: number): void {
     this._currentPage.set(page);
     this.loadPayments();
+  }
+
+  selectedPayment = signal<PaymentRequest | null>(null);
+
+  onPaymentDetail(payment: PaymentRequest): void {
+    this.selectedPayment.set(payment);
+  }
+
+  onCloseDetail(): void {
+    this.selectedPayment.set(null);
   }
 }


### PR DESCRIPTION
# New feature: Payment Request Details Form
_A modal to view the full details of a payment request has been introduced, improving the user experience and accessibility._

### Main changes
- **New PaymentDetailModalComponent component**
  - Standalone, semantic (dl/dt/dd), responsive, and accessible.
  - Blurred background to highlight the modal.
  - Accessible close button.
  
- **Integration into the table and application page**
  - The “View Details” button in each row opens the modal with the information for the selected application.
  - The status of the modal and the selected payment are controlled from the page.
 
### How to test?

1. Go to the payment requests page.
2. Click “View Details” in any row.
3. The modal with the complete information should open.
4. You can close the modal with the (X) button or from the page logic.

### Technical notes

- The modal uses [`PaymentStatusPipe`](src/app/features/payment-requests/pipes/payment-status.pipe.ts) to display the status.
- The component is standalone and can be reused in other views.
- The semantics and accessibility of the layout have been improved.
