### PR TITLE
Cancellation duplicate requests

### DIFF
--- a/src/app/features/payment-requests/components/payment-create-modal/payment-create-modal.component.html
+++ b/src/app/features/payment-requests/components/payment-create-modal/payment-create-modal.component.html
@@ -29,7 +29,7 @@
                class="w-full border border-gray-300 rounded-md p-2 "/>
         <p *ngIf="f['descripcion'].touched && f['descripcion'].invalid" 
            class="text-red-500 text-sm">
-          La descripción es obligatoria y debe tener al menos 3 caracteres.
+          La descripción es obligatoria y debe tener al menos 5 caracteres.
         </p>
       </div>
 

--- a/src/app/features/payment-requests/components/payment-create-modal/payment-create-modal.component.ts
+++ b/src/app/features/payment-requests/components/payment-create-modal/payment-create-modal.component.ts
@@ -73,7 +73,7 @@ export class PaymentCreateModalComponent {
 
   constructor(private fb: FormBuilder) {
     this.form = this.fb.group<CreatePaymentRequestForm>({
-      descripcion: this.fb.control('', { validators: [Validators.required, Validators.minLength(3)] }),
+      descripcion: this.fb.control('', { validators: [Validators.required, Validators.minLength(5)] }),
       importe: this.fb.control(null, { validators: [Validators.required, Validators.min(1)] }),
       fecha_vto: this.fb.control('', { validators: [Validators.required] }),
       recargo: this.fb.control(null, { validators: [Validators.min(1)] }),

--- a/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.html
+++ b/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.html
@@ -26,11 +26,11 @@
 
    <app-payment-loader *ngIf="isLoading()"></app-payment-loader>
 
-    <div *ngIf="error()" class="bg-red-50 border border-red-200 rounded-lg p-6">
-      <p class="text-red-700">{{ error() }}</p>
+    <div *ngIf="errorMessage" class="bg-red-50 border border-red-200 rounded-lg p-6">
+      <p class="text-red-700">{{ errorMessage }}</p>
     </div>
 
-    <div *ngIf="errorMessage" class="error-message">
+    <div *ngIf="errorMessage" class="errorMessage">
       {{ errorMessage }}
     </div>
 


### PR DESCRIPTION
## Implements request cancellation and corrects validation
This PR introduces two main improvements:
1. Payment List Refactoring
2. Correction in the Creation Modal
---
Previously, if a user clicked quickly on different pages in the list, multiple HTTP requests were triggered in parallel. This could cause a response from an earlier page (e.g., page 2) to arrive after a more recent one (e.g., page 4), causing the user interface to display incorrect and outdated data. This behavior is a bug known as a “race condition.”

### The Implemented Solution
To solve this, the imperative approach of direct calls was abandoned and a reactive pattern was implemented:
- Subject as an event source: An RxJS Subject (loadPaymentsTrigger$) was created to centralize page change and list refresh events.
- SwitchMap operator: The logic of the API request now resides within a switchMap. This operator is key to the solution: when it receives a new page event, it automatically cancels any previous HTTP requests that were still in progress and launches a new one. This ensures that only the user's last action is processed.
- Lifecycle management: The takeUntil(destroy$) pattern is used to ensure that the Subject subscription is cleaned up properly when the component is destroyed, preventing memory leaks.
---
Changes Included
- PaymentListPageComponent:
  - Refactoring of onPageChange and onRefresh to emit values to the new Subject.
  - Implementation of data loading logic within ngOnInit using switchMap.
  - Added ngOnDestroy for proper unsubscription.
- PaymentCreateModalComponent:
  - Adjustment to form validation rules for the description field.
