### PR TITLE
refactor(templates): migration to modern syntax with @if/@for in components

### DIFF
--- a/src/app/features/payment-requests/components/payment-create-modal/payment-create-modal.component.html
+++ b/src/app/features/payment-requests/components/payment-create-modal/payment-create-modal.component.html
@@ -27,10 +27,11 @@
         <label class="block text-sm font-medium text-gray-700">Descripción</label>
         <input type="text" formControlName="descripcion"
                class="w-full border border-gray-300 rounded-md p-2 "/>
-        <p *ngIf="f['descripcion'].touched && f['descripcion'].invalid" 
-           class="text-red-500 text-sm">
+        @if (f['descripcion'].touched && f['descripcion'].invalid) {
+        <p class="text-red-500 text-sm">
           La descripción es obligatoria y debe tener al menos 5 caracteres.
         </p>
+        }
       </div>
 
       <!-- Importe -->
@@ -38,24 +39,27 @@
             <label class="block text-sm font-medium text-gray-700">Importe</label>
             <input type="number" formControlName="importe"
                 class="w-full border border-gray-300 rounded-md p-2"/>
-            <p *ngIf="f['importe'].touched && f['importe'].errors?.['required']" 
-            class="text-red-500 text-sm">
+            @if (f['importe'].touched && f['importe'].errors?.['required']) {
+            <p class="text-red-500 text-sm">
             El importe es obligatorio.
             </p>
-            <p *ngIf="f['importe'].touched && f['importe'].errors?.['invalid']" 
-                class="text-red-500 text-sm">
+            }
+            @if (f['importe'].touched && f['importe'].errors?.['invalid']) {
+            <p class="text-red-500 text-sm">
                 {{ f['importe'].errors?.['invalid'] }}
             </p>
+            }
         </div>
 
         <div>
             <label class="block text-sm font-medium text-gray-700">Recargo</label>
             <input type="number" formControlName="recargo"
                     class="w-full border border-gray-300 rounded-md p-2"/>
-            <p *ngIf="f['importe'].touched && f['importe'].errors?.['invalid']" 
-                class="text-red-500 text-sm">
+            @if (f['recargo'].touched && f['recargo'].errors?.['invalid']) {
+            <p class="text-red-500 text-sm">
                 {{ f['importe'].errors?.['invalid'] }}
             </p>
+            }
         </div>
 
         <!-- Fecha Vencimiento -->
@@ -63,10 +67,11 @@
             <label class="block text-sm font-medium text-gray-700">Fecha Vencimiento</label>
             <input type="date" formControlName="fecha_vto"
                 class="w-full border border-gray-300 rounded-md p-2"/>
-            <p *ngIf="f['fecha_vto'].touched && f['fecha_vto'].invalid" 
-            class="text-red-500 text-sm">
+            @if (f['fecha_vto'].touched && f['fecha_vto'].invalid) {
+            <p class="text-red-500 text-sm">
             La fecha de vencimiento es obligatoria.
             </p>
+            }
         </div>
 
         <div>
@@ -80,10 +85,11 @@
         <label class="block text-sm font-medium text-gray-700">Referencia Externa</label>
         <input type="text" formControlName="referencia_externa"
                class="w-full border border-gray-300 rounded-md p-2"/>
-        <p *ngIf="f['referencia_externa'].touched && f['referencia_externa'].invalid" 
-           class="text-red-500 text-sm">
+        @if (f['referencia_externa'].touched && f['referencia_externa'].invalid) {
+        <p class="text-red-500 text-sm">
           La referencia externa es obligatoria.
         </p>
+        }
       </div>
 
       <!-- Botones -->

--- a/src/app/features/payment-requests/components/payment-detail-modal/payment-detail-modal.component.html
+++ b/src/app/features/payment-requests/components/payment-detail-modal/payment-detail-modal.component.html
@@ -25,7 +25,7 @@
     </header>
 
     <!-- Contenido -->
-    <div *ngIf="payment as payment; else noData">
+     @if (payment) {
       <dl class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <!-- ID -->
         <div>
@@ -42,14 +42,20 @@
           <dt class="text-sm text-gray-500">Importe Pagado</dt>
           <dd class="font-semibold text-gray-800">{{ payment.importe_pagado | currency:'USD' }}</dd>
         </div>
-        <div *ngIf="payment.importe" class="md:col-span-2">
+
+        @if (payment.importe){
+        <div class="md:col-span-2">
           <dt class="text-sm text-gray-500">Importe Original</dt>
           <dd class="font-semibold text-gray-800">{{ payment.importe | currency:'USD' }}</dd>
         </div>
-        <div *ngIf="payment.importe_vencido" class="col-span-2">
+        }
+        @if (payment.importe_vencido){
+        <div class="col-span-2">
           <dt class="text-sm text-gray-500">Importe Vencido</dt>
           <dd class="font-semibold text-red-600">{{ payment.importe_vencido | currency:'USD' }}</dd>
         </div>
+        }
+
         <!-- Estado y medio de pago -->
         <div>
           <dt class="text-sm text-gray-500">Estado</dt>
@@ -66,11 +72,9 @@
           <dd class="font-semibold">{{ payment.medio_pago }}</dd>
         </div>
       </dl>
-    </div>
-
-    <ng-template #noData>
+      } @else {
       <p class="text-gray-500">No hay información disponible.</p>
-    </ng-template>
+      }
   </section>
 </div>
 

--- a/src/app/features/payment-requests/components/payment-list/payment-list.component.html
+++ b/src/app/features/payment-requests/components/payment-list/payment-list.component.html
@@ -11,8 +11,8 @@
       </tr>
     </thead>
     <tbody class="divide-y divide-gray-200 bg-white"> 
+      @for (payment of payments; track payment.id_sp) {
       <tr
-        *ngFor="let payment of payments"
         class="hover:bg-gray-50"
         (click)="onPaymentSelect(payment)"
       >
@@ -46,6 +46,7 @@
           </button>
         </td>
       </tr>
+      }
     </tbody>
   </table>
 </div>

--- a/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.html
+++ b/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.html
@@ -14,50 +14,44 @@
         class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors duration-300 w-40">
         Crear Solicitud
       </button>
-
+      @if (isCreateModalOpen()) {
       <app-payment-create-modal
-        *ngIf="isCreateModalOpen()"
         (close)="onCloseCreate()"
         (create)="onCreatePayment($event)">
       </app-payment-create-modal>
+      }
     </div>
   </header>
 
-
-   <app-payment-loader *ngIf="isLoading()"></app-payment-loader>
-
-    <div *ngIf="errorMessage" class="bg-red-50 border border-red-200 rounded-lg p-6">
-      <p class="text-red-700">{{ errorMessage }}</p>
+    @if (isLoading()) {
+   <app-payment-loader></app-payment-loader>
+    } @else if (error()) {
+    <div class="bg-red-50 border border-red-200 rounded-lg p-6">
+      <p class="text-red-700">{{ error() }}</p>
     </div>
-
-    <div *ngIf="errorMessage" class="errorMessage">
-      {{ errorMessage }}
-    </div>
-
+  } @else {
       <!-- Lista de pagos -->
     <app-payment-list
-      *ngIf="!isLoading() && !error()"
       [payments]="pagos()"
       (paymentDetail)="onPaymentDetail($event)">
     </app-payment-list>
-
-    <app-payment-detail-modal
-      *ngIf="selectedPayment()"
-      [payment]="selectedPayment()"
-      (closed)="onCloseDetail()">
-    </app-payment-detail-modal>
-
-   <!-- Mensaje cuando no hay pagos  -->
-    <div *ngIf="!isLoading() && !error() && pagos().length === 0"  
-          class="flex items-center justify-center h-96 text-gray-500">
-      <p>No se encontraron resultados</p>
-    </div>
-
-      <app-pagination
+    @if (pagos().length === 0) {
+      <div class="flex items-center justify-center h-96 text-gray-500">
+        <p>No se encontraron resultados</p>
+      </div>
+    }
+    <app-pagination
         [currentPage]="currentPage()"
         [totalItems]="totalElements()" 
         [itemsPerPage]="itemsPerPage()"
         (pageChange)="onPageChange($event)">
-      </app-pagination>
+    </app-pagination>
+  }
+  @if (selectedPayment()) {
+    <app-payment-detail-modal
+      [payment]="selectedPayment()"
+      (closed)="onCloseDetail()">
+    </app-payment-detail-modal>
+  }
 </main>
 

--- a/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.ts
+++ b/src/app/features/payment-requests/pages/payment-list-page/payment-list-page.component.ts
@@ -23,7 +23,6 @@ import Swal from 'sweetalert2';
   selector: 'app-payment-list-page',
   standalone: true,
   imports: [
-    CommonModule,
     PaymentListComponent,
     PaymentLoaderComponent,
     PaginationComponent,

--- a/src/app/shared/components/search-box.component.html
+++ b/src/app/shared/components/search-box.component.html
@@ -16,8 +16,8 @@
       />
 
       <!-- Botón limpiar -->
+       @if (searchControl.value) {
       <button
-        *ngIf="searchControl.value"
         type="button"
         (click)="clearSearch()"
         class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
@@ -28,4 +28,5 @@
                 d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
+      }
 </div>


### PR DESCRIPTION
This PR updates the templates of several components to use the modern syntax of Angular 16+ with structural decorators (@if, @for) instead of traditional directives (*ngIf, *ngFor).

### Main changes

- payment-create-modal.component.html: use of @if for validations in the form.
- payment-detail-modal.component.html: replacement of conditions with @if.
- payment-list.component.html: migration of loops with @for.
- payment-list-page.component.html: simplification with decorators.