### PR TITLE
Refactor: introduction of generics in paginated responses

### DIFF
--- a/src/app/features/payment-requests/models/payment-request.model.ts
+++ b/src/app/features/payment-requests/models/payment-request.model.ts
@@ -23,14 +23,14 @@ export interface PaymentRequest {
 
 export type PaymentStatus = 'PROCESADA' | 'PENDIENTE' | 'CANCELADA' | 'RECHAZADA' | 'VENCIDA';
 
-export type PaymentRequestsResponse = PaymentRequest[];
+export interface Sort {
+  sorted: boolean;
+  unsorted: boolean;
+  empty: boolean;
+}
 
 export interface Pageable {
-  sort: {
-    sorted: boolean;
-    unsorted: boolean;
-    empty: boolean;
-  };
+  sort: Sort;
   offset: number;
   pageNumber: number;
   pageSize: number;
@@ -38,23 +38,21 @@ export interface Pageable {
   unpaged: boolean;
 }
 
-export interface PaginatedPaymentResponse {
-  content: PaymentRequest[];
+export interface PaginatedResponse<T> {
+  content: T[];
   pageable: Pageable;
   last: boolean;
   totalPages: number;
   totalElements: number;
   size: number;
-  number: number; // El número de la página actual (base 0)
-  sort: {
-    sorted: boolean;
-    unsorted: boolean;
-    empty: boolean;
-  };
+  number: number; // número de página actual (base 0)
+  sort: Sort;
   first: boolean;
   numberOfElements: number;
   empty: boolean;
 }
+
+export type PaginatedPaymentResponse = PaginatedResponse<PaymentRequest>;
 
 export interface CreatePaymentRequest {
   importe: number;

--- a/src/app/features/payment-requests/services/payment-requests.service.ts
+++ b/src/app/features/payment-requests/services/payment-requests.service.ts
@@ -3,7 +3,7 @@ import { Observable, map } from 'rxjs';
 import {
   PaymentRequest,
   CreatePaymentRequest,
-  PaginatedPaymentResponse,
+  PaginatedResponse,
 } from '../models/payment-request.model';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { ConfigService } from '../../../core/services/config.service';
@@ -18,13 +18,13 @@ export class PaymentRequestsService {
   getPaymentRequests(
     pageNumber: number,
     pageSize: number,
-  ): Observable<PaginatedPaymentResponse> {
+  ): Observable<PaginatedResponse<PaymentRequest>> {
 
     const params = new HttpParams()
       .set('pageNumber', pageNumber.toString())
       .set('pageSize', pageSize.toString());
 
-    return this.http.get<PaginatedPaymentResponse>(
+    return this.http.get<PaginatedResponse<PaymentRequest>>(
       this.configService.solicitudPagoPaged,
       { params }
     );


### PR DESCRIPTION
This PR introduces improvements to models and services to apply good typing practices in TypeScript:

### Main changes
- Introduces `PaginatedResponse<T>` as a generic interface to handle paginated responses from any entity.
- Removes duplications of `Pageable` and `Sort` in models.
- Maintains an alias `PaginatedPaymentResponse` for compatibility with existing code.
- `PaymentRequestsService` is adapted to use the new generics.
- Se cierra el issue [#15](https://github.com/IsaAlegre/PaymentManager/issues/15)